### PR TITLE
chore(release): add unified pnpm version lifecycle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "verify": "pnpm run build && VAULT_NAME=${VAULT_NAME:-Test} obsidian vault=\"$VAULT_NAME\" plugin:reload id=obsidian-eagle-plugin && node scripts/verify-plugin.mjs --vault \"$VAULT_NAME\" \"$@\"",
     "e2e": "wdio run test/e2e/wdio.conf.ts",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "version": "node scripts/version.mjs",
+    "postversion": "git push && git push --tags"
   },
   "keywords": [
     "obsidian",

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const version = process.env.npm_package_version;
+if (!version) throw new Error('npm_package_version is not set. Run via: pnpm version <semver>');
+
+const manifest = JSON.parse(readFileSync('manifest.json', 'utf8'));
+const { minAppVersion } = manifest;
+manifest.version = version;
+writeFileSync('manifest.json', JSON.stringify(manifest, null, '\t') + '\n');
+
+const versions = JSON.parse(readFileSync('versions.json', 'utf8'));
+versions[version] = minAppVersion;
+writeFileSync('versions.json', JSON.stringify(versions, null, '\t') + '\n');


### PR DESCRIPTION
## Summary
- Add `scripts/version.mjs` — syncs `manifest.json` and `versions.json` on `pnpm version`
- Add `version` and `postversion` hooks to `package.json`

## Usage
\`\`\`bash
pnpm version patch   # or minor / major / 1.2.3
# → bumps package.json → syncs manifest.json + versions.json → git commit + tag → push
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)