### PR TITLE
chore(ci): remove SonarCloud job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,25 +39,3 @@ jobs:
         if: always()
         with:
           files: 'test-results.xml'
-      - name: Upload coverage data
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov.info
-          path: coverage/lcov.info
-  SonarScan:
-    needs: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Download coverage data
-        uses: actions/download-artifact@v4
-        with:
-          name: lcov.info
-          path: coverage/
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `SonarScan` job entirely (no `sonar-project.properties` or `SONAR_TOKEN` configured)
- Remove `Upload coverage data` artifact step (only needed for SonarCloud)
- `Publish Test Results` step retained — still surfaces test results on PRs

## Result

CI pipeline: Build → lint → test → publish test results only.