### PR TITLE
feat(settings): redesign settings UI — folder pickers, connection badge, remove conversion settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "obsidian-eagle-plugin",
 	"name": "Eagle Integration",
 	"version": "2.5.0",
-	"minAppVersion": "0.15.0",
+	"minAppVersion": "1.7.2",
 	"description": "Upload images to Eagle and integrate with Obsidian notes.",
 	"author": "Beomsu Koh",
 	"authorUrl": "https://github.com/GoBeromsu/obsidian-eagle-plugin",

--- a/src/EaglePlugin.ts
+++ b/src/EaglePlugin.ts
@@ -542,6 +542,7 @@ export default class EaglePlugin extends Plugin {
         void this.insertSelectedSearchItem(editor, item)
       },
       this._settings.debugSearchDiagnostics,
+      this._settings.searchDebounceMs,
     ).open()
   }
 
@@ -580,7 +581,7 @@ export default class EaglePlugin extends Plugin {
     let markdownImage = ''
     try {
       const folderName = this.resolveTargetEagleFolderForActiveFile()
-      const normalizedFile = await normalizeImageForUpload(file, this._settings)
+      const normalizedFile = await normalizeImageForUpload(file)
       const { itemId, fileUrl, ext } = await this._eagleUploader.upload(normalizedFile, { folderName })
 
       if (cancelled) {

--- a/src/plugin-settings.ts
+++ b/src/plugin-settings.ts
@@ -1,5 +1,3 @@
-export type FallbackImageFormat = 'jpeg' | 'png' | 'webp'
-
 export interface ObsidianEagleFolderMapping {
   obsidianFolder: string
   eagleFolder: string
@@ -11,10 +9,9 @@ export interface EaglePluginSettings {
   eagleFolderName: string
   folderMappings: ObsidianEagleFolderMapping[]
   debugSearchDiagnostics: boolean
-  fallbackImageFormat: FallbackImageFormat
-  conversionQualityForJpeg: number
   cacheFolderName: string
   deduplicateUploads: boolean
+  searchDebounceMs: number
 }
 
 export const DEFAULT_SETTINGS: EaglePluginSettings = {
@@ -23,8 +20,7 @@ export const DEFAULT_SETTINGS: EaglePluginSettings = {
   eagleFolderName: '',
   folderMappings: [],
   debugSearchDiagnostics: false,
-  fallbackImageFormat: 'jpeg',
-  conversionQualityForJpeg: 0.9,
   cacheFolderName: 'eagle-cache',
   deduplicateUploads: true,
+  searchDebounceMs: 300,
 }

--- a/src/ui/EaglePluginSettingsTab.ts
+++ b/src/ui/EaglePluginSettingsTab.ts
@@ -1,9 +1,26 @@
-import { App, ButtonComponent, Notice, PluginSettingTab, Setting, TextComponent } from 'obsidian'
+import {
+  App,
+  ButtonComponent,
+  DropdownComponent,
+  Notice,
+  PluginSettingTab,
+  Setting,
+  TextComponent,
+  TFolder,
+} from 'obsidian'
 
 import EaglePlugin from '../EaglePlugin'
 import { ObsidianEagleFolderMapping } from '../plugin-settings'
+import { EagleFolderWithPath } from '../uploader/EagleUploader'
 import { sanitizeFolderMappings } from '../utils/folder-mapping'
 import RenameCacheModal from './RenameCacheModal'
+import VaultFolderSuggestModal from './VaultFolderSuggestModal'
+
+type EagleFolderList = EagleFolderWithPath[]
+
+function resolveVaultFolderPath(folder: TFolder): string {
+  return folder.path === '/' ? '' : folder.path
+}
 
 export default class EaglePluginSettingsTab extends PluginSettingTab {
   plugin: EaglePlugin
@@ -25,6 +42,8 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
 
     // ── Connection ──────────────────────────────────────────────────────────
     containerEl.createEl('h3', { text: 'Connection' })
+
+    const statusBadge = containerEl.createEl('div', { cls: 'eagle-connection-status', text: '○ Checking…' })
 
     new Setting(containerEl)
       .setName('Eagle API Host')
@@ -60,6 +79,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
           btn.setDisabled(true)
           btn.setButtonText('Testing…')
           const connected = await this.plugin.eagleUploader.isConnected()
+          this.updateConnectionBadge(statusBadge, connected)
           if (connected) {
             new Notice('Connected to Eagle')
           } else {
@@ -69,8 +89,6 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
           btn.setButtonText('Test Connection')
         })
       })
-
-    containerEl.createEl('hr')
 
     // ── Upload ───────────────────────────────────────────────────────────────
     containerEl.createEl('h3', { text: 'Upload' })
@@ -91,64 +109,70 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
         }),
     )
 
-    void this.upgradeToFolderDropdown(folderSetting)
+    // Fetch Eagle folders once; used by Upload dropdown + Folder Mapping rows
+    const eagleFoldersPromise = this.fetchEagleFolders(statusBadge)
 
-    new Setting(containerEl)
-      .setName('Fallback format for unsupported images')
-      .setDesc('Convert unsupported image formats to this format before upload.')
-      .addDropdown((dropdown) =>
-        dropdown
-          .addOption('jpeg', 'jpeg')
-          .addOption('png', 'png')
-          .addOption('webp', 'webp')
-          .setValue(this.plugin.settings.fallbackImageFormat)
-          .onChange((value) => {
-            this.plugin.settings.fallbackImageFormat = value as 'jpeg' | 'png' | 'webp'
-            void this.plugin.saveSettings()
-          }),
-      )
-
-    new Setting(containerEl)
-      .setName('JPEG conversion quality')
-      .setDesc('Quality for JPEG conversion output (0–1).')
-      .addSlider((slider) =>
-        slider
-          .setLimits(0, 1, 0.05)
-          .setValue(this.plugin.settings.conversionQualityForJpeg)
-          .setDynamicTooltip()
-          .onChange((value) => {
-            this.plugin.settings.conversionQualityForJpeg = value
-            void this.plugin.saveSettings()
-          }),
-      )
-
-    containerEl.createEl('hr')
+    void eagleFoldersPromise.then((folders) => {
+      if (folders.length > 0) {
+        this.upgradeToFolderDropdown(folderSetting, folders)
+      }
+    })
 
     // ── Cache ────────────────────────────────────────────────────────────────
     containerEl.createEl('h3', { text: 'Cache' })
 
+    let cacheTextComponent: TextComponent
+
     new Setting(containerEl)
-      .setName('Cache folder name')
+      .setName('Cache folder')
       .setDesc(
         "Images are cached here (supports subfolders: '80. References/07. eagle'). After renaming, confirm to move existing images.",
       )
-      .addText((text) =>
+      .addText((text) => {
+        cacheTextComponent = text
         text
           .setPlaceholder('eagle-cache')
           .setValue(this.plugin.settings.cacheFolderName)
           .onChange((value) => {
             this.plugin.settings.cacheFolderName = value.trim() || 'eagle-cache'
             void this.plugin.saveSettings()
+          })
+      })
+      .addButton((btn) => {
+        btn.setButtonText('Browse').onClick(() => {
+          new VaultFolderSuggestModal(this.app, (folder: TFolder) => {
+            this.plugin.settings.cacheFolderName = resolveVaultFolderPath(folder) || 'eagle-cache'
+            void this.plugin.saveSettings()
+            cacheTextComponent.setValue(this.plugin.settings.cacheFolderName)
+          }).open()
+        })
+      })
+
+    // ── Folder Mapping ───────────────────────────────────────────────────────
+    this.renderFolderMappingsSection(containerEl, eagleFoldersPromise)
+
+    // ── Search ───────────────────────────────────────────────────────────────
+    containerEl.createEl('h3', { text: 'Search' })
+
+    new Setting(containerEl)
+      .setName('Search debounce delay')
+      .setDesc('How long to wait after typing before triggering a search (ms).')
+      .addSlider((slider) =>
+        slider
+          .setLimits(100, 1000, 50)
+          .setValue(this.plugin.settings.searchDebounceMs)
+          .setDynamicTooltip()
+          .onChange((value) => {
+            this.plugin.settings.searchDebounceMs = value
+            void this.plugin.saveSettings()
           }),
       )
 
-    containerEl.createEl('hr')
-
-    // ── Advanced ─────────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Advanced' })
+    // ── Debug ─────────────────────────────────────────────────────────────────
+    containerEl.createEl('h3', { text: 'Debug' })
 
     new Setting(containerEl)
-      .setName('Search diagnostics (debug)')
+      .setName('Search diagnostics')
       .setDesc('Log search/thumbnail resolution details to the dev console.')
       .addToggle((toggle) =>
         toggle
@@ -158,20 +182,66 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
             void this.plugin.saveSettings()
           }),
       )
-
-    containerEl.createEl('hr')
-
-    this.renderFolderMappingsSection(containerEl)
   }
 
-  private renderFolderMappingsSection(containerEl: HTMLElement): void {
-    containerEl.createEl('h3', { text: 'Folder Mapping (Obsidian -> Eagle)' })
+  private updateConnectionBadge(badge: HTMLElement, connected: boolean): void {
+    badge.removeClass('is-connected', 'is-disconnected')
+    if (connected) {
+      badge.addClass('is-connected')
+      badge.setText('● Connected')
+    } else {
+      badge.addClass('is-disconnected')
+      badge.setText('● Disconnected')
+    }
+  }
+
+  private async fetchEagleFolders(badge?: HTMLElement): Promise<EagleFolderList> {
+    try {
+      const folders = await this.plugin.eagleUploader.listFolders()
+      if (badge) this.updateConnectionBadge(badge, true)
+      return folders
+    } catch (err) {
+      if (badge) this.updateConnectionBadge(badge, false)
+      if (!(err instanceof Error && err.message.includes('connect'))) {
+        console.error('Eagle: unexpected error while loading folder list', err)
+      }
+      return []
+    }
+  }
+
+  private upgradeToFolderDropdown(folderSetting: Setting, folders: EagleFolderList): void {
+    if (!folderSetting.settingEl.isConnected) return
+    folderSetting.controlEl.empty()
+    folderSetting.addDropdown((dropdown) => {
+      dropdown.addOption('', '— default folder —')
+      for (const folder of folders) {
+        dropdown.addOption(folder.path, folder.path)
+      }
+      const currentValue = this.plugin.settings.eagleFolderName
+      const exists = folders.some((f) => f.path === currentValue)
+      if (currentValue && !exists) {
+        dropdown.addOption(currentValue, currentValue)
+      }
+      dropdown.setValue(currentValue)
+      dropdown.onChange((value) => {
+        this.plugin.settings.eagleFolderName = value
+        void this.plugin.saveSettings()
+      })
+    })
+  }
+
+  private renderFolderMappingsSection(
+    containerEl: HTMLElement,
+    eagleFoldersPromise: Promise<EagleFolderList>,
+  ): void {
+    containerEl.createEl('h3', { text: 'Folder Mapping (Obsidian → Eagle)' })
     containerEl.createEl('p', {
       cls: 'eagle-folder-mapping-description',
       text: 'Route uploads by active note folder. Longest matching folder rule is applied.',
     })
 
     const listContainer = containerEl.createDiv({ cls: 'eagle-folder-mapping-list' })
+
     const renderRows = () => {
       listContainer.empty()
 
@@ -184,7 +254,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       }
 
       this.plugin.settings.folderMappings.forEach((mapping, index) => {
-        this.renderFolderMappingRow(listContainer, mapping, index, renderRows)
+        this.renderFolderMappingRow(listContainer, mapping, index, renderRows, eagleFoldersPromise)
       })
     }
 
@@ -193,10 +263,8 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       .setButtonText('Add mapping')
       .setCta()
       .onClick(() => {
-        this.plugin.settings.folderMappings.push({
-          obsidianFolder: '',
-          eagleFolder: '',
-        })
+        this.plugin.settings.folderMappings.push({ obsidianFolder: '', eagleFolder: '' })
+        void this.plugin.saveSettings()
         renderRows()
       })
 
@@ -208,71 +276,87 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
     mapping: ObsidianEagleFolderMapping,
     index: number,
     onRemoved: () => void,
+    eagleFoldersPromise: Promise<EagleFolderList>,
   ): void {
     const row = listContainer.createDiv({ cls: 'eagle-folder-mapping-row' })
 
-    const addMappingInput = (
-      placeholder: string,
-      value: string,
-      field: keyof ObsidianEagleFolderMapping,
-    ) => {
-      const input = new TextComponent(row)
-        .setPlaceholder(placeholder)
-        .setValue(value)
-        .onChange((newValue) => {
-          const currentMapping = this.plugin.settings.folderMappings[index]
-          if (!currentMapping) return
-          currentMapping[field] = newValue
+    // ── Obsidian folder: text + Browse ──────────────────────────────────────
+    const obsidianInput = new TextComponent(row)
+      .setPlaceholder('Obsidian folder (e.g. Projects/Design)')
+      .setValue(mapping.obsidianFolder)
+      .onChange((newValue) => {
+        const m = this.plugin.settings.folderMappings[index]
+        if (!m) return
+        m.obsidianFolder = newValue
+        void this.plugin.saveSettings()
+      })
+    obsidianInput.inputEl.addClass('eagle-folder-mapping-input')
+
+    new ButtonComponent(row)
+      .setButtonText('Browse')
+      .setTooltip('Pick vault folder')
+      .onClick(() => {
+        new VaultFolderSuggestModal(this.app, (folder: TFolder) => {
+          const m = this.plugin.settings.folderMappings[index]
+          if (!m) return
+          m.obsidianFolder = resolveVaultFolderPath(folder)
+          obsidianInput.setValue(m.obsidianFolder)
           void this.plugin.saveSettings()
-        })
-      input.inputEl.addClass('eagle-folder-mapping-input')
-    }
+        }).open()
+      })
 
-    addMappingInput('Obsidian folder (ex: Projects/Design)', mapping.obsidianFolder, 'obsidianFolder')
-    addMappingInput('Eagle folder (ex: Design)', mapping.eagleFolder, 'eagleFolder')
+    // ── Eagle folder: container holds text input, upgraded to dropdown when Eagle resolves ──
+    const eagleControlDiv = row.createDiv({ cls: 'eagle-folder-control' })
 
+    const eagleInput = new TextComponent(eagleControlDiv)
+      .setPlaceholder('Eagle folder (e.g. Design)')
+      .setValue(mapping.eagleFolder)
+      .onChange((newValue) => {
+        const m = this.plugin.settings.folderMappings[index]
+        if (!m) return
+        m.eagleFolder = newValue
+        void this.plugin.saveSettings()
+      })
+    eagleInput.inputEl.addClass('eagle-folder-mapping-input')
+
+    void eagleFoldersPromise.then((folders) => {
+      if (!row.isConnected || folders.length === 0) return
+
+      const m = this.plugin.settings.folderMappings[index]
+      if (!m) return
+
+      eagleControlDiv.empty()
+      const dropdown = new DropdownComponent(eagleControlDiv)
+      dropdown.selectEl.addClass('eagle-folder-mapping-input')
+
+      dropdown.addOption('', '— pick Eagle folder —')
+      for (const f of folders) {
+        dropdown.addOption(f.path, f.path)
+      }
+
+      const currentValue = m.eagleFolder
+      if (currentValue && !folders.some((f) => f.path === currentValue)) {
+        dropdown.addOption(currentValue, currentValue)
+      }
+
+      dropdown.setValue(currentValue)
+      dropdown.onChange((value) => {
+        const cur = this.plugin.settings.folderMappings[index]
+        if (!cur) return
+        cur.eagleFolder = value
+        void this.plugin.saveSettings()
+      })
+    })
+
+    // ── Remove button ────────────────────────────────────────────────────────
     new ButtonComponent(row)
       .setIcon('trash')
       .setTooltip('Remove mapping')
       .onClick(() => {
         this.plugin.settings.folderMappings.splice(index, 1)
-        onRemoved()
         void this.plugin.saveSettings()
+        onRemoved()
       })
-  }
-
-  /**
-   * Try to replace the plain text input with a live dropdown populated from Eagle.
-   * If Eagle is unreachable, keep the text input and update the description.
-   */
-  private async upgradeToFolderDropdown(folderSetting: Setting): Promise<void> {
-    try {
-      const folders = await this.plugin.eagleUploader.listFolders()
-      folderSetting.controlEl.empty()
-      folderSetting.addDropdown((dropdown) => {
-        dropdown.addOption('', '— default folder —')
-        for (const folder of folders) {
-          dropdown.addOption(folder.path, folder.path)
-        }
-        const currentValue = this.plugin.settings.eagleFolderName
-        const exists = folders.some((f) => f.path === currentValue)
-        if (currentValue && !exists) {
-          dropdown.addOption(currentValue, currentValue)
-        }
-        dropdown.setValue(currentValue)
-        dropdown.onChange((value) => {
-          this.plugin.settings.eagleFolderName = value
-          void this.plugin.saveSettings()
-        })
-      })
-    } catch (err) {
-      if (!(err instanceof Error && err.message.includes('connect'))) {
-        console.error('Eagle: unexpected error while loading folder list', err)
-      }
-      folderSetting.setDesc(
-        'The folder name in Eagle where images will be saved. (Eagle not reachable — type folder name manually)',
-      )
-    }
   }
 
   override hide() {

--- a/src/ui/EagleSearchPickerModal.ts
+++ b/src/ui/EagleSearchPickerModal.ts
@@ -4,7 +4,6 @@ import EagleApiError from '../uploader/EagleApiError'
 import EagleUploader, { EagleItemSearchResult } from '../uploader/EagleUploader'
 import { fileUrlToDisplayUrl } from '../utils/file-url'
 
-const SEARCH_DEBOUNCE_MS = 300
 const SEARCH_RESULT_LIMIT = 100
 const THUMBNAIL_CONCURRENCY = 6
 
@@ -14,6 +13,7 @@ export default class EagleSearchPickerModal extends Modal {
   private readonly uploader: EagleUploader
   private readonly onChoose: (item: EagleItemSearchResult) => void
   private readonly debugSearchDiagnostics: boolean
+  private readonly debounceMs: number
 
   private keywordInput: TextComponent
   private statusEl: HTMLElement
@@ -29,11 +29,13 @@ export default class EagleSearchPickerModal extends Modal {
     uploader: EagleUploader,
     onChoose: (item: EagleItemSearchResult) => void,
     debugSearchDiagnostics: boolean,
+    debounceMs = 300,
   ) {
     super(app)
     this.uploader = uploader
     this.onChoose = onChoose
     this.debugSearchDiagnostics = debugSearchDiagnostics
+    this.debounceMs = debounceMs
     this.setTitle('Search Eagle library')
   }
 
@@ -115,7 +117,7 @@ export default class EagleSearchPickerModal extends Modal {
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null
       void this.runSearch()
-    }, SEARCH_DEBOUNCE_MS)
+    }, this.debounceMs)
   }
 
   private async runSearch(): Promise<void> {

--- a/src/ui/VaultFolderSuggestModal.ts
+++ b/src/ui/VaultFolderSuggestModal.ts
@@ -1,0 +1,23 @@
+import { App, FuzzySuggestModal, TFolder } from 'obsidian'
+
+export default class VaultFolderSuggestModal extends FuzzySuggestModal<TFolder> {
+  private readonly onChoose: (folder: TFolder) => void
+
+  constructor(app: App, onChoose: (folder: TFolder) => void) {
+    super(app)
+    this.onChoose = onChoose
+    this.setPlaceholder('Type to search vault folders…')
+  }
+
+  getItems(): TFolder[] {
+    return this.app.vault.getAllFolders(true)
+  }
+
+  getItemText(folder: TFolder): string {
+    return folder.path === '/' ? '/ (vault root)' : folder.path
+  }
+
+  onChooseItem(folder: TFolder): void {
+    this.onChoose(folder)
+  }
+}

--- a/src/utils/image-format.ts
+++ b/src/utils/image-format.ts
@@ -1,5 +1,3 @@
-import { FallbackImageFormat } from '../plugin-settings'
-
 const HEIC_SIGNATURE_BRANDS = new Set(['heic', 'heix', 'hevc', 'heim', 'heis', 'hevm'])
 const HEIF_SIGNATURE_BRANDS = new Set(['mif1', 'msf1'])
 const AVIF_SIGNATURE_BRANDS = new Set(['avif'])
@@ -21,8 +19,6 @@ const KNOWN_IMAGE_EXTENSIONS = new Set([
   'svg',
   'webp',
 ])
-
-const CONVERSION_TARGET_FORMATS = new Set<FallbackImageFormat>(['jpeg', 'png', 'webp'])
 
 export type ImageFormatDetectionSource = 'signature' | 'mime' | 'extension' | 'fallback'
 
@@ -201,27 +197,6 @@ export function isLikelyImageFile(file: { type?: string; name: string }) {
   if (mime.startsWith('image/')) return true
 
   return isKnownImageExtension(extractFileExtension(file.name))
-}
-
-export function isConversionSafeTarget(format: string) {
-  return CONVERSION_TARGET_FORMATS.has(normalizeExtension(format) as FallbackImageFormat)
-}
-
-export function canonicalImageExtensionForFormat(format: string) {
-  const normalized = normalizeExtension(format)
-  if (normalized === 'jpeg') return 'jpg'
-  return normalized
-}
-
-export function mimeTypeForFallbackFormat(format: FallbackImageFormat) {
-  switch (format) {
-    case 'jpeg':
-      return 'image/jpeg'
-    case 'png':
-      return 'image/png'
-    case 'webp':
-      return 'image/webp'
-  }
 }
 
 export function replaceFileExtension(fileName: string, extension: string) {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,12 +1,8 @@
 import { EditorPosition, ReferenceCache } from 'obsidian'
 
-import { EaglePluginSettings, FallbackImageFormat } from '../plugin-settings'
 import {
-  canonicalImageExtensionForFormat,
   detectImageFormat,
-  isKnownImageExtension,
   isRenderableImageExtension,
-  mimeTypeForFallbackFormat,
   replaceFileExtension,
 } from './image-format'
 
@@ -21,93 +17,6 @@ function normalizeImageForBrowser(image: File): File {
 
   return new File([image], image.name, {
     type: image.type,
-    lastModified: image.lastModified,
-  })
-}
-
-function clampNumber(value: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, value))
-}
-
-async function decodeImageElement(image: File): Promise<HTMLImageElement> {
-  const element = new Image()
-  const objectUrl = URL.createObjectURL(image)
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      element.onload = () => resolve()
-      element.onerror = () => reject(new Error('Failed to decode image for conversion'))
-      element.src = objectUrl
-    })
-
-    return element
-  } finally {
-    URL.revokeObjectURL(objectUrl)
-  }
-}
-
-function hasClose(resource: ImageBitmap | HTMLImageElement): resource is ImageBitmap {
-  return 'close' in resource && typeof resource.close === 'function'
-}
-
-async function convertImageToFormat(
-  image: File,
-  format: FallbackImageFormat,
-  quality: number,
-): Promise<File> {
-  if (typeof document === 'undefined' || !document.createElement) {
-    throw new Error('Canvas conversion is not available in this runtime')
-  }
-
-  const fileMimeType = mimeTypeForFallbackFormat(format)
-  if (!fileMimeType) {
-    throw new Error(`Unsupported conversion format: ${format}`)
-  }
-
-  let source: ImageBitmap | HTMLImageElement
-  try {
-    if (typeof createImageBitmap === 'function') {
-      source = await createImageBitmap(image)
-    } else {
-      source = await decodeImageElement(image)
-    }
-  } catch {
-    source = await decodeImageElement(image)
-  }
-
-  const { width, height } = source
-  const canvas = document.createElement('canvas')
-  const ctx = canvas.getContext('2d')
-  if (!ctx) {
-    if (hasClose(source)) {
-      source.close()
-    }
-    throw new Error('Unable to get 2D context for image conversion')
-  }
-
-  canvas.width = width
-  canvas.height = height
-
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
-  ctx.drawImage(source, 0, 0)
-
-  if (hasClose(source)) {
-    source.close()
-  }
-
-  const extension = canonicalImageExtensionForFormat(format)
-  const convertedName = replaceFileExtension(image.name, extension)
-  const normalizedQuality = clampNumber(quality, 0, 1)
-  const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob(resolve, fileMimeType, format === 'jpeg' ? normalizedQuality : undefined),
-  )
-
-  if (!blob) {
-    throw new Error(`Failed to convert image to ${format}`)
-  }
-
-  return new File([blob], convertedName, {
-    type: fileMimeType,
     lastModified: image.lastModified,
   })
 }
@@ -142,28 +51,23 @@ function ensureTypeAndExtensionMatch(
   })
 }
 
-export async function normalizeImageForUpload(image: File, settings: EaglePluginSettings): Promise<File> {
+export async function normalizeImageForUpload(image: File): Promise<File> {
   const normalized = normalizeImageForBrowser(image)
   const detected = detectImageFormat(await normalized.arrayBuffer(), normalized.name, normalized.type)
-
-  const shouldAttemptConversion =
-    isKnownImageExtension(detected.extension) ||
-    (detected.source === 'signature' && Boolean(detected.extension)) ||
-    normalized.type.startsWith('image/')
 
   if (detected.recognized && isRenderableImageExtension(detected.extension)) {
     return ensureTypeAndExtensionMatch(normalized, detected)
   }
 
-  if (!shouldAttemptConversion) {
-    return normalized
+  // Eagle handles native formats (HEIC, TIFF, etc.) natively — no conversion needed.
+  // Log unrecognized formats so upload failures are easier to trace.
+  if (!detected.recognized) {
+    console.warn('Eagle: image format not recognized, passing to Eagle as-is', {
+      name: image.name,
+      type: image.type,
+    })
   }
-
-  return convertImageToFormat(
-    normalized,
-    settings.fallbackImageFormat,
-    settings.conversionQualityForJpeg,
-  )
+  return normalized
 }
 
 function removeReferenceIfPresent(

--- a/styles.css
+++ b/styles.css
@@ -167,4 +167,40 @@
 
 .eagle-folder-mapping-input {
   flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.eagle-folder-control {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+}
+
+/* ── Connection Status Badge ────────────────────────────────────────────── */
+
+.eagle-connection-status {
+  font-size: var(--font-ui-smaller);
+  margin-bottom: 8px;
+  color: var(--text-muted);
+}
+
+.eagle-connection-status.is-connected {
+  color: var(--text-success);
+}
+
+.eagle-connection-status.is-disconnected {
+  color: var(--text-error);
+}
+
+/* ── Eagle folder dropdown in mapping rows ──────────────────────────────── */
+
+select.eagle-folder-mapping-input {
+  background: var(--background-primary);
+  color: var(--text-normal);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  padding: 4px 8px;
+  font-size: var(--font-ui-small);
+  height: var(--input-height);
 }

--- a/test/image-format.test.ts
+++ b/test/image-format.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-import { DEFAULT_SETTINGS } from '../src/plugin-settings'
 import {
   detectImageFormat,
   isLikelyImageFile,
@@ -73,7 +72,7 @@ describe(isLikelyImageFile, () => {
 })
 
 describe('normalizeImageForUpload', () => {
-  it('throws when conversion is required but runtime conversion API is unavailable', async () => {
+  it('passes non-renderable files through as-is (Eagle handles natively)', async () => {
     const heicSignature = [
       0x00,
       0x00,
@@ -96,10 +95,16 @@ describe('normalizeImageForUpload', () => {
     const file = new File([new Uint8Array(heicSignature)], 'photo.heic', {
       type: 'image/heic',
     })
+    const result = await normalizeImageForUpload(file)
+    expect(result.name).toBe('photo.heic')
+    expect(result.type).toBe('image/heic')
+  })
 
-    await expect(normalizeImageForUpload(file, DEFAULT_SETTINGS)).rejects.toThrow(
-      'Canvas conversion is not available',
-    )
+  it('passes completely unrecognized files through unchanged', async () => {
+    const file = new File([new Uint8Array([0xde, 0xad, 0xbe, 0xef])], 'data.bin', { type: '' })
+    const result = await normalizeImageForUpload(file)
+    expect(result.name).toBe('data.bin')
+    expect(result.type).toBe('')
   })
 
   it('keeps renderable files with valid signatures', async () => {
@@ -124,7 +129,7 @@ describe('normalizeImageForUpload', () => {
     const file = new File([new Uint8Array(pngSignature)], 'existing.png', {
       type: 'image/png',
     })
-    const normalized = await normalizeImageForUpload(file, DEFAULT_SETTINGS)
+    const normalized = await normalizeImageForUpload(file)
     expect(normalized.type).toBe('image/png')
     expect(normalized.name).toBe('existing.png')
   })


### PR DESCRIPTION
## Summary

- **Connection section**: live status badge (● Connected / ● Disconnected) shown on tab open; Test Connection button also updates it
- **Upload**: Eagle folder dropdown populated from live API (no change to behavior, just cleaner fetch path)
- **Cache folder**: Browse button opens `VaultFolderSuggestModal` (fuzzy vault folder picker)
- **Folder Mapping rows**: Obsidian folder Browse button + Eagle folder `DropdownComponent` (async upgrade from text input when Eagle is reachable)
- **Search section**: configurable debounce slider (100–1000ms, default 300ms)
- **Debug section**: moved to very bottom
- **Removed**: `hr` separators, fallback image format setting, JPEG quality slider — Eagle handles HEIC/TIFF/etc. natively; `normalizeImageForUpload` now passes unrecognized formats through as-is
- **Fixes**: orphaned `FallbackImageFormat` import + dead functions in `image-format.ts`, `minAppVersion` bumped to `1.7.2` (`getAllFolders` API requirement), CSS vars use documented Obsidian tokens (`--text-success`, `--text-error`, `--font-ui-smaller`)

## Closes

- #18 (settings section grouping)

## Test plan

- [ ] `pnpm build` — no errors
- [ ] `pnpm test` — 36 tests pass
- [ ] `pnpm lint` — no errors
- [ ] Manual QA: open settings tab → badge shows Checking… then Connected/Disconnected
- [ ] Test Connection button updates badge + shows Notice
- [ ] Cache folder Browse → fuzzy picker → fills text field
- [ ] Folder mapping: Add mapping → Browse picks Obsidian folder → Eagle dropdown shows live folders
- [ ] Search debounce slider 100–1000ms updates in real-time
- [ ] Debug section at very bottom, no `---` separators between sections
- [ ] Drop HEIC image → uploads without conversion (passes through to Eagle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)