### PR TITLE
fix: folder mapping UI, nested paths, incomplete row notice

### DIFF
--- a/src/ui/EaglePluginSettingsTab.ts
+++ b/src/ui/EaglePluginSettingsTab.ts
@@ -3,6 +3,7 @@ import {
   ButtonComponent,
   DropdownComponent,
   EventRef,
+  Notice,
   PluginSettingTab,
   Setting,
   TextComponent,
@@ -333,6 +334,8 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       })
     }
 
+    renderRows()
+
     const actionsContainer = containerEl.createDiv({ cls: 'eagle-folder-mapping-actions' })
     new ButtonComponent(actionsContainer)
       .setButtonText('Add mapping')
@@ -343,8 +346,6 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
         renderRows()
         this.updatePreviewDesc()
       })
-
-    renderRows()
   }
 
   private renderFolderMappingRow(
@@ -503,9 +504,14 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
     }
     this.previewDescEl = null
 
+    const before = this.plugin.settings.folderMappings.length
     this.plugin.settings.folderMappings = sanitizeFolderMappings(
       this.plugin.settings.folderMappings,
     )
+    const removed = before - this.plugin.settings.folderMappings.length
+    if (removed > 0) {
+      new Notice(`Eagle: removed ${removed} incomplete folder mapping(s)`)
+    }
     void this.plugin.saveSettings()
 
     const newFolder = this.plugin.settings.cacheFolderName

--- a/src/ui/EagleUploader.ts
+++ b/src/ui/EagleUploader.ts
@@ -401,14 +401,17 @@ export default class EagleUploader {
     return result
   }
 
-  async createFolder(name: string, signal?: AbortSignal): Promise<string> {
+  async createFolder(name: string, signal?: AbortSignal, parentId?: string): Promise<string> {
     const { eagleHost, eaglePort } = this.settings
     const url = `http://${eagleHost}:${eaglePort}${EAGLE_API_ENDPOINTS.FOLDER_CREATE}`
+
+    const body: Record<string, string> = { folderName: name }
+    if (parentId) body.parent = parentId
 
     const data = await this.requestJson<EagleListResponse>(
       url,
       'POST',
-      JSON.stringify({ folderName: name }),
+      JSON.stringify(body),
       signal,
     )
 
@@ -449,18 +452,45 @@ export default class EagleUploader {
     // Match strategy:
     // 1. Full path — slash-separated input like "Resources/Obsidian" maps to a truly nested folder.
     // 2. Root name — simple input like "Obsidian" maps to a top-level folder (no parent).
-    // Falls through to create a new root-level folder if neither matches.
+    // Falls through to create missing folder(s).
     const byPath = flat.find((f) => f.path === name)
     if (byPath) return byPath.id
 
     const byName = flat.find((f) => f.name === name && !f.path.includes('/'))
     if (byName) return byName.id
 
-    if (name.includes('/')) {
-      // eslint-disable-next-line no-console
-      console.warn('Eagle: nested folder path not found in library; creating root folder with literal name', { name })
+    if (!name.includes('/')) {
+      return this.createFolder(name, signal)
     }
-    return this.createFolder(name, signal)
+
+    // Recursively create nested folder structure (e.g. "Resources/Obsidian")
+    return this.createNestedFolders(name, flat, signal)
+  }
+
+  private async createNestedFolders(
+    path: string,
+    flat: EagleFolderWithPath[],
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const segments = path.split('/')
+    let lastId = ''
+    let parentId: string | undefined
+    let currentPath = ''
+
+    for (const segment of segments) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment
+      const existing = flat.find((f) => f.path === currentPath)
+      if (existing) {
+        lastId = existing.id
+        parentId = existing.id
+      } else {
+        lastId = await this.createFolder(segment, signal, parentId)
+        parentId = lastId
+        flat.push({ id: lastId, name: segment, path: currentPath })
+      }
+    }
+
+    return lastId
   }
 
   async listFolders(): Promise<EagleFolderWithPath[]> {

--- a/styles.css
+++ b/styles.css
@@ -213,6 +213,17 @@
   min-width: 0;
 }
 
+/* TextComponent / DropdownComponent renders inside a wrapper div — stretch it */
+.eagle-folder-control > div,
+.eagle-folder-control > select {
+  flex: 1;
+  min-width: 0;
+}
+
+.eagle-folder-mapping-actions {
+  margin-top: 8px;
+}
+
 /* ── Connection Status Badge ────────────────────────────────────────────── */
 
 .eagle-connection-status {


### PR DESCRIPTION
## Summary

- **#51** — Folder mapping UI layout: moved "Add mapping" button below rows, added CSS spacing for `.eagle-folder-mapping-actions`, made Eagle folder input/dropdown stretch to fill available space via `> div` / `> select` flex rules
- **#52** — Nested Eagle folder paths: replaced silent root-folder creation with recursive `createNestedFolders()` that walks each path segment, reusing existing folders and creating missing ones with the Eagle API's `parent` parameter
- **#53** — Incomplete mapping rows: added a `Notice` in the settings tab `hide()` when sanitization removes incomplete rows, so the user knows their WIP mappings were pruned

Closes #51, closes #52, closes #53

## Test plan

- [ ] Add a folder mapping, verify "Add mapping" button is below the rows
- [ ] Verify both Obsidian and Eagle folder inputs stretch equally
- [ ] Set an Eagle folder mapping to a nested path (e.g. `Resources/Obsidian`) that doesn't exist — verify it creates the nested structure in Eagle, not a root folder with a slash
- [ ] Add a mapping with only the Obsidian side filled, close settings — verify a Notice appears saying the incomplete row was removed
- [ ] `pnpm run ci` passes (build + lint + 72 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)