### PR TITLE
fix: address Obsidian community bot feedback

### DIFF
--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -1,5 +1,21 @@
 import 'obsidian'
 
+/** Shape of the internal Node.js fs/path fields exposed by Obsidian's desktop adapter. */
+export interface NodeAdapterFs {
+  readFile(path: string, callback: (err: NodeJS.ErrnoException | null, buffer: Buffer) => void): void
+  writeFile(path: string, data: Buffer, callback: (err: NodeJS.ErrnoException | null) => void): void
+  unlink(path: string, callback: (err: NodeJS.ErrnoException | null) => void): void
+}
+
+export interface NodeAdapterPath {
+  join(...parts: string[]): string
+}
+
+export interface NodeDataAdapter {
+  fs: NodeAdapterFs
+  path: NodeAdapterPath
+}
+
 declare module 'obsidian' {
   interface MarkdownSubView {
     clipboardManager: ClipboardManager

--- a/src/ui/EagleCacheManager.ts
+++ b/src/ui/EagleCacheManager.ts
@@ -1,5 +1,7 @@
 import { App } from 'obsidian'
 
+import type { NodeDataAdapter } from '../types/obsidian'
+
 export interface CacheStats {
   fileCount: number
   totalSizeBytes: number
@@ -81,9 +83,9 @@ export default class EagleCacheManager {
 
   async cacheFromOsPath(itemId: string, ext: string, absolutePath: string): Promise<void> {
     await this.ensureCacheFolder()
-    const adapter = this.app.vault.adapter as any
+    const adapter = this.app.vault.adapter as unknown as NodeDataAdapter
     const data = await new Promise<ArrayBuffer>((resolve, reject) => {
-      adapter.fs.readFile(absolutePath, (err: any, buffer: Buffer) => {
+      adapter.fs.readFile(absolutePath, (err: NodeJS.ErrnoException | null, buffer: Buffer) => {
         if (err) {
           reject(err instanceof Error ? err : new Error(String(err)))
           return

--- a/src/ui/EaglePluginSettingsTab.ts
+++ b/src/ui/EaglePluginSettingsTab.ts
@@ -51,15 +51,15 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
 
     containerEl.empty()
 
-    containerEl.createEl('h2', { text: 'Eagle Plugin Settings' })
+    new Setting(containerEl).setHeading().setName('Eagle plugin settings')
 
     // ── Connection ──────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Connection' })
+    new Setting(containerEl).setHeading().setName('Connection')
 
     const statusBadge = containerEl.createEl('div', { cls: 'eagle-connection-status', text: '○ Checking…' })
 
     new Setting(containerEl)
-      .setName('Eagle API Host')
+      .setName('Eagle API host')
       .setDesc('The host for your running Eagle instance.')
       .addText((text) =>
         text
@@ -72,7 +72,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       )
 
     new Setting(containerEl)
-      .setName('Eagle API Port')
+      .setName('Eagle API port')
       .setDesc('The port for your running Eagle instance.')
       .addText((text) =>
         text
@@ -104,10 +104,10 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       })
 
     // ── Upload ───────────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Upload' })
+    new Setting(containerEl).setHeading().setName('Upload')
 
     const folderSetting = new Setting(containerEl)
-      .setName('Eagle Folder Name')
+      .setName('Eagle folder name')
       .setDesc(
         'The folder name in Eagle where images will be saved. Leave empty to save to the default folder.',
       )
@@ -160,7 +160,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
     })
 
     // ── Cache ────────────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Cache' })
+    new Setting(containerEl).setHeading().setName('Cache')
 
     let cacheTextComponent: TextComponent
 
@@ -226,7 +226,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
     this.renderDestinationPreview(containerEl)
 
     // ── Search ───────────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Search' })
+    new Setting(containerEl).setHeading().setName('Search')
 
     new Setting(containerEl)
       .setName('Search debounce delay')
@@ -243,7 +243,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       )
 
     // ── Debug ─────────────────────────────────────────────────────────────────
-    containerEl.createEl('h3', { text: 'Debug' })
+    new Setting(containerEl).setHeading().setName('Debug')
 
     new Setting(containerEl)
       .setName('Search diagnostics')
@@ -310,7 +310,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
     containerEl: HTMLElement,
     eagleFoldersPromise: Promise<EagleFolderList>,
   ): void {
-    containerEl.createEl('h3', { text: 'Folder Mapping (Obsidian → Eagle)' })
+    new Setting(containerEl).setHeading().setName('Folder mapping (Obsidian → Eagle)')
     containerEl.createEl('p', {
       cls: 'eagle-folder-mapping-description',
       text: 'Route uploads by active note folder. Longest matching folder rule is applied.',
@@ -447,7 +447,7 @@ export default class EaglePluginSettingsTab extends PluginSettingTab {
       this.leafChangeRef = null
     }
 
-    containerEl.createEl('h3', { text: 'Destination Preview' })
+    new Setting(containerEl).setHeading().setName('Destination preview')
 
     const setting = new Setting(containerEl)
       .setName('Current upload destination')

--- a/src/ui/EagleUploader.ts
+++ b/src/ui/EagleUploader.ts
@@ -2,6 +2,8 @@ import { tmpdir } from 'os'
 
 import { App, requestUrl } from 'obsidian'
 
+import type { NodeDataAdapter } from '../types/obsidian'
+
 import EagleApiError from '../domain/EagleApiError'
 import { EaglePluginSettings } from '../domain/settings'
 import { extractFileExtension } from '../utils/image-format'
@@ -197,10 +199,8 @@ export default class EagleUploader {
       const ext = extFromUrl || extractFileExtension(image.name) || 'jpg'
       return { itemId, fileUrl, ext }
     } finally {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const fs = (this.app.vault?.adapter as any)?.fs
+      const fs = (this.app.vault?.adapter as unknown as NodeDataAdapter)?.fs
       if (fs?.unlink) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         fs.unlink(tempFilePath, (err: NodeJS.ErrnoException | null) => {
           if (err && err.code !== 'ENOENT') {
             // eslint-disable-next-line no-console
@@ -213,14 +213,14 @@ export default class EagleUploader {
 
   private async saveToTempFile(image: File): Promise<string> {
     const tempFileName = `eagle-temp-${generatePseudoRandomId()}.${image.name.split('.').pop()}`
-    const adapter = this.app.vault.adapter as any
+    const adapter = this.app.vault.adapter as unknown as NodeDataAdapter
     const osTempDir = tmpdir()
     const tempFilePath = adapter.path.join(osTempDir, tempFileName)
     const arrayBuffer = await image.arrayBuffer()
     const buffer = Buffer.from(arrayBuffer)
 
     return new Promise((resolve, reject) => {
-      adapter.fs.writeFile(tempFilePath, buffer, (err: any) => {
+      adapter.fs.writeFile(tempFilePath, buffer, (err: NodeJS.ErrnoException | null) => {
         if (err) {
           reject(err instanceof Error ? err : new Error(String(err)))
           return


### PR DESCRIPTION
## Summary

- Replace `createEl('h2'/'h3', ...)` headings with `new Setting(containerEl).setHeading().setName(...)` in settings tab
- Apply sentence case to all `setName()` labels (Eagle API host/port, Eagle folder name, Destination preview, Folder mapping)
- Replace `as any` adapter casts with a typed `NodeDataAdapter` interface in `EagleCacheManager` and `EagleUploader`
- Add `NodeDataAdapter` / `NodeAdapterFs` / `NodeAdapterPath` interfaces to `src/types/obsidian.d.ts`

## Test plan

- [ ] CI passes (`pnpm run ci`) — build + lint (72 tests passing)
- [ ] Settings tab renders all section headings correctly
- [ ] Upload and cache operations still work in Obsidian (no runtime regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)